### PR TITLE
added skip_cleanup to deploy step in travis config

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,7 @@ script:
 after_success:
 - codecov
 deploy:
+  skip_cleanup: true
 - provider: script
   script: bash ./.travis/build-deploy.sh prod us-east-1
   on:


### PR DESCRIPTION
Build for previous PR failed with the following error: 
```
HEAD detached at ca7b8b1
Untracked files:
  (use "git add <file>..." to include in what will be committed)
	coverage.xml
```

It seems like `coverage.xml` is a build artifact in `codecov`, which can be seen in the build: 
```
$ codecov
      _____          _
     / ____|        | |
    | |     ___   __| | ___  ___ _____   __
    | |    / _ \ / _  |/ _ \/ __/ _ \ \ / /
    | |___| (_) | (_| |  __/ (_| (_) \ V /
     \_____\___/ \____|\___|\___\___/ \_/
                                    v2.0.9
==> Detecting CI provider
    Travis Detected
==> Preparing upload
==> Processing gcov (disable by -X gcov)
    Executing gcov (find /home/travis/build/makerdao/chief-keeper -type f -name '*.gcno'  -exec gcov -pb  {} +)
==> Collecting reports
    Generating coverage xml reports for Python
    + /home/travis/build/makerdao/chief-keeper/coverage.xml bytes=8939
==> Appending environment variables
    + TRAVIS_PYTHON_VERSION
    + TRAVIS_OS_NAME
==> Uploading
    .url https://codecov.io
    .query 
```

[Following this advice](https://travis-ci.community/t/travis-adding-git-output-at-the-end-of-jobs/5388), I've added `skip_cleanup:true` in `.travis.yml` to prevent Travis from resetting your working directory and deleting all changes made during the build. 

Merging this PR will test this change.

