### PR TITLE
try dropping `skip_cleanup` at the end of `deploy:`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,11 +18,11 @@ script:
 after_success:
 - codecov
 deploy:
-  skip_cleanup: true
 - provider: script
   script: bash ./.travis/build-deploy.sh prod us-east-1
   on:
     branch: master
+  skip_cleanup: true
 notifications:
   email: false
 env:

--- a/.travis.yml
+++ b/.travis.yml
@@ -16,13 +16,12 @@ install:
 script:
 - ./test.sh
 after_success:
-- codecov
+- echo "codecov will exec here"
 deploy:
 - provider: script
   script: bash ./.travis/build-deploy.sh prod us-east-1
   on:
     branch: master
-  skip_cleanup: true
 notifications:
   email: false
 env:


### PR DESCRIPTION
Trying to fix the issue described in #6.

To be specific, the issue was in the form of a frozen travis build: 
![image](https://user-images.githubusercontent.com/6872751/97030154-40c2c400-1513-11eb-887e-cd5fe07b3cc6.png)
