### PR TITLE
added support for EOA and 0x0 spells

### DIFF
--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -212,7 +212,7 @@ class ChiefKeeper:
                 self.logger.info(f'Scheduling spell ({yay})')
                 spell.schedule().transact(gas_price=self.gas_price)
         else:
-            self.logger.info(f'Spell is an EOA or 0x0, so keeper will not attempt to call schedule()')
+            self.logger.warning(f'Spell is an EOA or 0x0, so keeper will not attempt to call schedule()')
 
 
     def check_eta(self):
@@ -248,7 +248,7 @@ class ChiefKeeper:
                     else:
                         del etas[yay]
                 else:
-                    self.logger.info(f'Spell is an EOA or 0x0, so keeper will not attempt to call cast()')
+                    self.logger.warning(f'Spell is an EOA or 0x0, so keeper will not attempt to call cast()')
                     del etas[yay]
 
         self.database.db.update({'upcoming_etas': etas}, doc_ids=[3])

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -195,22 +195,24 @@ class ChiefKeeper:
             self.logger.info(f'Old hat ({hat}) with Approvals {hatApprovals}')
             self.logger.info(f'New hat ({contender}) with Approvals {highestApprovals}')
             self.dss.ds_chief.lift(Address(contender)).transact(gas_price=self.gas_price)
-            spell = DSSSpell(self.web3, Address(contender))
         else:
             self.logger.info(f'Current hat ({hat}) with Approvals {hatApprovals}')
-            spell = DSSSpell(self.web3, Address(hat))
 
-        self.check_schedule(spell, yay)
+        # Read the hat; either is equivalent to the contender or old hat
+        hatNew = self.dss.ds_chief.get_hat().address
+        if hatNew != hat:
+            self.logger.info(f'Confirmed ({contender}) now has the hat')
 
+        spell = DSSSpell(self.web3, Address(hatNew)) if is_contract_at(self.web3, Address(hatNew)) else None
 
-    def check_schedule(self, spell: DSSSpell, yay: str):
-        """ Schedules spells that haven't been scheduled nor casted """
-        if is_contract_at(self.web3, Address(yay)):
-
+        # Schedules spells that haven't been scheduled nor casted
+        if spell is not None:
             # Functional with DSSSpells but not DSSpells (not compatiable with DSPause)
             if spell.done() == False and self.database.get_eta_inUnix(spell) == 0:
                 self.logger.info(f'Scheduling spell ({yay})')
                 spell.schedule().transact(gas_price=self.gas_price)
+        else:
+            self.logger.info(f'Spell is an EOA or 0x0, so keeper will not attempt to call schedule()')
 
 
     def check_eta(self):
@@ -231,15 +233,22 @@ class ChiefKeeper:
 
         for yay in yays:
             if etas[yay] <= now:
-                spell = DSSSpell(self.web3, Address(yay))
 
-                if spell.done() == False:
-                    receipt = spell.cast().transact(gas_price=self.gas_price)
+                spell = DSSSpell(self.web3, Address(yay)) if is_contract_at(self.web3, Address(yay)) else None
 
-                    if receipt is None or receipt.successful == True:
+                if spell is not None:
+
+                    if spell.done() == False:
+
+                        self.logger.info(f'Casting spell ({spell.address.address})')
+                        receipt = spell.cast().transact(gas_price=self.gas_price)
+
+                        if receipt is None or receipt.successful == True:
+                            del etas[yay]
+                    else:
                         del etas[yay]
-
                 else:
+                    self.logger.info(f'Spell is an EOA or 0x0, so keeper will not attempt to call cast()')
                     del etas[yay]
 
         self.database.db.update({'upcoming_etas': etas}, doc_ids=[3])

--- a/install-dev.sh
+++ b/install-dev.sh
@@ -12,4 +12,4 @@ virtualenv --python=`which python3` _virtualenv
 # is that it can detect different versions of the same dependency and fail with a "Double requirement given"
 # error message.
 pip install $(cat requirements.txt $(find lib -name requirements.txt | sort) | sort | uniq | sed 's/ *== */==/g')
-pip install $(cat requirements-dev.txt $(find lib -name requirements-dev.txt | sort) | sort | uniq | sed 's/ *== */==/g')
+pip install $(cat lib/pymaker/requirements-dev.txt $(find lib -name lib/pymaker/requirements-dev.txt | sort) | sort | uniq | sed 's/ *== */==/g')

--- a/tests/test_keeper_chief.py
+++ b/tests/test_keeper_chief.py
@@ -121,7 +121,7 @@ class TestChiefKeeper:
         keeper.check_hat()
         keeper.check_eta()
 
-        # Give 1000 MKR to our_address
+        # Give 5000 MKR to our_address
         amount = Wad.from_number(5000)
         mint_approve_lock(mcd, amount, our_address)
 


### PR DESCRIPTION
Added support to handle case where an EOA or 0x0 spell gets the hat, in which a [`WARNING` log](https://docs.python.org/3/library/logging.html#logging.Logger.warning) will be printed on the console. 

Previously, the keeper printed the following exception:
![exception_log](https://user-images.githubusercontent.com/6872751/101960847-32ad2d80-3bbd-11eb-8c81-e0d5b40e2150.png)
