### PR TITLE
TECH-1204 - Adding the health-check functionality to Chief-Keeper

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,6 +1,7 @@
 FROM python:3.6.6
 
-RUN groupadd -r keeper && useradd -d /home/keeper -m --no-log-init -r -g keeper keeper && \
+RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list && \
+    groupadd -r keeper && useradd -d /home/keeper -m --no-log-init -r -g keeper keeper && \
     apt-get -y update && \
     apt-get -y install python3-pip jshon jq virtualenv pkg-config openssl libssl-dev autoconf libtool libsecp256k1-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM python:3.6.6
+FROM python:3.7-buster
 
 RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list && \
     groupadd -r keeper && useradd -d /home/keeper -m --no-log-init -r -g keeper keeper && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,6 @@
 FROM python:3.7-buster
 
-RUN echo "deb http://archive.debian.org/debian stretch main" > /etc/apt/sources.list && \
-    groupadd -r keeper && useradd -d /home/keeper -m --no-log-init -r -g keeper keeper && \
+RUN groupadd -r keeper && useradd -d /home/keeper -m --no-log-init -r -g keeper keeper && \
     apt-get -y update && \
     apt-get -y install python3-pip jshon jq virtualenv pkg-config openssl libssl-dev autoconf libtool libsecp256k1-dev && \
     apt-get clean && rm -rf /var/lib/apt/lists/*

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -35,6 +35,18 @@ from pymaker.deployment import DssDeployment
 
 from auction_keeper.gas import DynamicGasPrice
 
+HEALTHCHECK_FILE_PATH = "/tmp/health.log"
+
+
+def healthy(func):
+    def inner():
+        print("==================== Healthcheck ====================")
+        with open(HEALTHCHECK_FILE_PATH, "W") as healthcheck_file:
+            healthcheck_file.write(int(time.time()))
+        func()
+
+    return inner
+
 
 class ChiefKeeper:
     """Keeper that lifts the hat and streamlines executive actions"""
@@ -214,6 +226,7 @@ class ChiefKeeper:
 
         self.logger.info(result)
 
+    @healthy
     def process_block(self):
         """Callback called on each new block. If too many errors, terminate the keeper.
         This is the entrypoint to the Keeper's monitoring logic

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -35,19 +35,6 @@ from pymaker.deployment import DssDeployment
 
 from auction_keeper.gas import DynamicGasPrice
 
-HEALTHCHECK_FILE_PATH = "/tmp/health.log"
-
-
-def healthy(func):
-    def wrapper(*args, **kwargs):
-        ts = int(time.time())
-        print(f"[{ts}] - healthy")
-        with open(HEALTHCHECK_FILE_PATH, "w") as f:
-            f.write(str(ts) + "\n")
-        return func(*args, **kwargs)
-
-    return wrapper
-
 
 class ChiefKeeper:
     """Keeper that lifts the hat and streamlines executive actions"""
@@ -141,7 +128,12 @@ class ChiefKeeper:
         parser.add_argument(
             "--gas-maximum", type=str, default=5000, help="gas strategy tuning"
         )
-
+        parser.add_argument(
+            "--health-check-file-path",
+            type=str,
+            default="/tmp/health.log",
+            help="path to health-check file",
+        )
         parser.set_defaults(cageFacilitated=False)
         self.arguments = parser.parse_args(args)
 
@@ -186,6 +178,17 @@ class ChiefKeeper:
             format="%(asctime)-15s %(levelname)-8s %(message)s",
             level=(logging.DEBUG if self.arguments.debug else logging.INFO),
         )
+
+    @staticmethod
+    def healthy(func):
+        def wrapper(self, *args, **kwargs):
+            ts = int(time.time())
+            self.logger.info(f"Health-check passed: {ts}")
+            with open(self.arguments.health_check_file_path, "w") as f:
+                f.write(str(ts) + "\n")
+            return func(*args, **kwargs)
+
+        return wrapper
 
     def main(self):
         """Initialize the lifecycle and enter into the Keeper Lifecycle controller.

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -181,9 +181,9 @@ class ChiefKeeper:
             level=(logging.DEBUG if self.arguments.debug else logging.INFO),
         )
 
-    def healthy(self, func):
+    def healthy(func):
         @wraps(func)
-        def wrapper(*args, **kwargs):
+        def wrapper(self, *args, **kwargs):
             ts = int(time.time())
             self.logger.info(f"Health-check passed: {ts}")
             with open(self.arguments.health_check_file_path, "w") as f:

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -39,13 +39,14 @@ HEALTHCHECK_FILE_PATH = "/tmp/health.log"
 
 
 def healthy(func):
-    def inner():
-        print("==================== Healthcheck ====================")
-        with open(HEALTHCHECK_FILE_PATH, "W") as healthcheck_file:
-            healthcheck_file.write(int(time.time()))
-        func()
+    def wrapper(*args, **kwargs):
+        ts = int(time.time())
+        print(f"[{ts}] - healthy")
+        with open(HEALTHCHECK_FILE_PATH, "w") as f:
+            f.write(str(ts) + "\n")
+        return func(*args, **kwargs)
 
-    return inner
+    return wrapper
 
 
 class ChiefKeeper:

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -35,6 +35,8 @@ from pymaker.deployment import DssDeployment
 
 from auction_keeper.gas import DynamicGasPrice
 
+from functools import wraps
+
 
 class ChiefKeeper:
     """Keeper that lifts the hat and streamlines executive actions"""
@@ -179,8 +181,9 @@ class ChiefKeeper:
             level=(logging.DEBUG if self.arguments.debug else logging.INFO),
         )
 
-    def healthy(func):
-        def wrapper(self, *args, **kwargs):
+    def healthy(self, func):
+        @wraps(func)
+        def wrapper(*args, **kwargs):
             ts = int(time.time())
             self.logger.info(f"Health-check passed: {ts}")
             with open(self.arguments.health_check_file_path, "w") as f:

--- a/chief_keeper/chief_keeper.py
+++ b/chief_keeper/chief_keeper.py
@@ -179,7 +179,6 @@ class ChiefKeeper:
             level=(logging.DEBUG if self.arguments.debug else logging.INFO),
         )
 
-    @staticmethod
     def healthy(func):
         def wrapper(self, *args, **kwargs):
             ts = int(time.time())

--- a/chief_keeper/database.py
+++ b/chief_keeper/database.py
@@ -30,7 +30,8 @@ from pymaker.deployment import DssDeployment
 
 
 class SimpleDatabase:
-    """ Wraps around the logic to create, update, and query the Keeper's local database """
+    """Wraps around the logic to create, update, and query the Keeper's local database"""
+
     def __init__(self, web3: Web3, block: int, network: str, deployment: DssDeployment):
         self.web3 = web3
         self.deployment_block = block
@@ -38,28 +39,32 @@ class SimpleDatabase:
         self.dss = deployment
 
     def create(self):
-        """ Updates a locally stored database with the DS-Chief state since its last update.
+        """Updates a locally stored database with the DS-Chief state since its last update.
         If a local database is not found, create one and query the DS-Chief state since its deployment.
         """
         parentpath = os.path.abspath(os.path.join("..", os.path.dirname(__file__)))
-        filepath = os.path.abspath(os.path.join(parentpath, "database", "db_"+self.network+".json"))
+        filepath = os.path.abspath(
+            os.path.join(parentpath, "database", "db_" + self.network + ".json")
+        )
 
         if os.path.isfile(filepath) and os.access(filepath, os.R_OK):
-        # checks if file exists
+            # checks if file exists
             result = "Simple database exists and is readable"
             self.db = TinyDB(filepath)
         else:
-            result = "Either file is missing or is not readable, creating simple database"
+            result = (
+                "Either file is missing or is not readable, creating simple database"
+            )
             self.db = TinyDB(filepath)
 
             blockNumber = self.web3.eth.blockNumber
-            self.db.insert({'last_block_checked_for_yays': blockNumber})
+            self.db.insert({"last_block_checked_for_yays": blockNumber})
 
             yays = self.get_yays(self.deployment_block, blockNumber)
-            self.db.insert({'yays': yays})
+            self.db.insert({"yays": yays})
 
             etas = self.get_etas(yays, blockNumber)
-            self.db.insert({'upcoming_etas': etas})
+            self.db.insert({"upcoming_etas": etas})
 
         return result
 
@@ -70,18 +75,17 @@ class SimpleDatabase:
         return etaInUnix
 
     def update_db_etas(self, blockNumber: int):
-        """ Add yays with upcoming etas """
+        """Add yays with upcoming etas"""
         yays = self.db.get(doc_id=2)["yays"]
         etas = self.get_etas(yays, blockNumber)
 
-        self.db.update({'upcoming_etas': etas}, doc_ids=[3])
+        self.db.update({"upcoming_etas": etas}, doc_ids=[3])
 
     def get_etas(self, yays, blockNumber: int):
-        """ Get all upcoming etas """
+        """Get all upcoming etas"""
         etas = {}
         for yay in yays:
-
-            #Check if yay is an address to an EOA or a contract
+            # Check if yay is an address to an EOA or a contract
             if is_contract_at(self.web3, Address(yay)):
                 spell = DSSSpell(self.web3, Address(yay))
                 eta = self.get_eta_inUnix(spell)
@@ -92,19 +96,19 @@ class SimpleDatabase:
         return etas
 
     def update_db_yays(self, currentBlockNumber: int):
-        """ Store yays that have been `etched` in DS-Chief since the last update """
+        """Store yays that have been `etched` in DS-Chief since the last update"""
         DBblockNumber = self.db.get(doc_id=1)["last_block_checked_for_yays"]
-        currentYays = self.get_yays(DBblockNumber,currentBlockNumber)
+        currentYays = self.get_yays(DBblockNumber, currentBlockNumber)
         oldYays = self.db.get(doc_id=2)["yays"]
 
         # Take out any duplicates
         newYays = list(dict.fromkeys(oldYays + currentYays))
 
-        self.db.update({'yays': newYays}, doc_ids=[2])
-        self.db.update({'last_block_checked_for_yays': currentBlockNumber}, doc_ids=[1])
+        self.db.update({"yays": newYays}, doc_ids=[2])
+        self.db.update({"last_block_checked_for_yays": currentBlockNumber}, doc_ids=[1])
 
     def get_yays(self, beginBlock: int, endBlock: int):
-        """ Get all `etched` yays within a given block range """
+        """Get all `etched` yays within a given block range"""
         etches = self.dss.ds_chief.past_etch_in_range(beginBlock, endBlock)
         maxYays = self.dss.ds_chief.get_max_yays()
 
@@ -115,12 +119,12 @@ class SimpleDatabase:
         return yays if not None else []
 
     def unpack_slate(self, slate, maxYays: int) -> List:
-        """ Unpack the slate into its yay constituents """
+        """Unpack the slate into its yay constituents"""
         yays = []
 
         for i in range(0, maxYays):
             try:
-                yay = [self.dss.ds_chief.get_yay(slate,i)]
+                yay = [self.dss.ds_chief.get_yay(slate, i)]
             except ValueError:
                 break
             yays = yays + yay

--- a/chief_keeper/spell.py
+++ b/chief_keeper/spell.py
@@ -33,12 +33,12 @@ class DSSSpell(Contract):
     """
 
     # This ABI and BIN was used from a modified McdIlkLineSpell.sol, located here: https://gist.github.com/godsflaw/3a6cfcdbe8cc08d5df8b03f1be0432df
-    abi = Contract._load_abi(__name__, 'abi/DSSSpell.abi')
-    bin = Contract._load_bin(__name__, 'abi/DSSSpell.bin')
+    abi = Contract._load_abi(__name__, "abi/DSSSpell.abi")
+    bin = Contract._load_bin(__name__, "abi/DSSSpell.bin")
 
     def __init__(self, web3: Web3, address: Address):
-        assert (isinstance(web3, Web3))
-        assert (isinstance(address, Address))
+        assert isinstance(web3, Web3)
+        assert isinstance(address, Address)
 
         self.web3 = web3
         self.address = address
@@ -57,10 +57,22 @@ class DSSSpell(Contract):
 
     @staticmethod
     def deploy(web3: Web3, pauseAddress: Address, vatAddress: Address):
-        return DSSSpell(web3=web3, address=Contract._deploy(web3, DSSSpell.abi, DSSSpell.bin, [pauseAddress.address, vatAddress.address]))
+        return DSSSpell(
+            web3=web3,
+            address=Contract._deploy(
+                web3,
+                DSSSpell.abi,
+                DSSSpell.bin,
+                [pauseAddress.address, vatAddress.address],
+            ),
+        )
 
     def schedule(self):
-        return Transact(self, self.web3, self.abi, self.address, self._contract, 'schedule', [])
+        return Transact(
+            self, self.web3, self.abi, self.address, self._contract, "schedule", []
+        )
 
     def cast(self):
-        return Transact(self, self.web3, self.abi, self.address, self._contract, 'cast', [])
+        return Transact(
+            self, self.web3, self.abi, self.address, self._contract, "cast", []
+        )

--- a/health-check.sh
+++ b/health-check.sh
@@ -1,0 +1,20 @@
+#!/bin/bash
+
+# Get the current Unix timestamp
+current_time=$(date +%s)
+
+# Get the Unix timestamp from the file
+file_time=$(cat /tmp/health.log)
+
+# Calculate the time difference in seconds
+time_diff=$((current_time - file_time))
+
+# Compare the time difference to 900 seconds (15 minutes)
+if [ "$time_diff" -gt 900 ]; then
+  # If the time difference is greater than 15 minutes, exit with error code 1
+  echo "Last health check was more than 15 minutes ago."
+  exit 1
+else
+  # Otherwise, exit with normal code 0
+  exit 0
+fi

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,5 +1,4 @@
 attrs == 19.1.0
-codecov == 2.0.16
 mock == 2.0.0
 pytest == 3.3.0
 pytest-asyncio == 0.9.0


### PR DESCRIPTION
1. Chief-Keeper starts as a loop processing blocks calling `process_block()` method
2. With this PR we add @healthy decorator which once called writes current UNIX timestamp to `/tmp/health.log`
3. We also add `health-check.sh` script which compares current UNIX timestamp with one in file `/tmp/health.log`
4. If delta is more than 15 minutes exit code = `1`, if less -- `0`
5. We will execute `health-check.sh` as ECS task health-check