### PR TITLE
TECH-2964 - Bumping Python to 3.9

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,5 +1,5 @@
 # Use an official Python runtime as a parent image
-FROM python:3.8-buster
+FROM python:3.9-buster
 
 # Add user and group for running the application
 RUN groupadd -r keeper && useradd -d /home/keeper -m --no-log-init -r -g keeper keeper && \

--- a/Dockerfile
+++ b/Dockerfile
@@ -14,7 +14,8 @@ WORKDIR /opt/keeper/chief-keeper
 COPY . .
 
 # Install submodules
-RUN git submodule update --init --recursive
+RUN git config --global --add safe.directory /opt/keeper/chief-keeper && \
+    git submodule update --init --recursive
 
 # Install any needed packages specified in requirements.txt
 # First copy only the requirements.txt to leverage Docker cache


### PR DESCRIPTION
**Python 3.10** doesn't work due to next Exception
```
Traceback (most recent call last):
  File "/usr/local/lib/python3.10/site-packages/pytz/lazy.py", line 3, in <module>
    from UserDict import DictMixin
ModuleNotFoundError: No module named 'UserDict'

During handling of the above exception, another exception occurred:

Traceback (most recent call last):
  File "/usr/local/lib/python3.10/runpy.py", line 196, in _run_module_as_main
    return _run_code(code, main_globals, None,
  File "/usr/local/lib/python3.10/runpy.py", line 86, in _run_code
    exec(code, run_globals)
  File "/opt/keeper/chief-keeper/chief_keeper/chief_keeper.py", line 34, in <module>
    from pymaker.lifecycle import Lifecycle
  File "/opt/keeper/chief-keeper/lib/pymaker/pymaker/lifecycle.py", line 24, in <module>
    import pytz
  File "/usr/local/lib/python3.10/site-packages/pytz/__init__.py", line 32, in <module>
    from pytz.lazy import LazyDict, LazyList, LazySet
  File "/usr/local/lib/python3.10/site-packages/pytz/lazy.py", line 5, in <module>
    from collections import Mapping as DictMixin
ImportError: cannot import name 'Mapping' from 'collections' (/usr/local/lib/python3.10/collections/__init__.py)
```